### PR TITLE
fix: use GitHub tsconfig in workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm install
 
       - name: 🔍 Type check
-        run: npx tsc -p tsconfig.json --noEmit
+        run: npx tsc -p tsconfig.github.json --noEmit
 
       - name: 🧪 Run tests
         run: npm test


### PR DESCRIPTION
### Motivation
- Use the repository's GitHub-specific TypeScript configuration for CI type checking instead of the default `tsconfig.json`.

### Description
- Update `.github/workflows/npm-publish.yml` to change the type-check step from `npx tsc -p tsconfig.json --noEmit` to `npx tsc -p tsconfig.github.json --noEmit`.

### Testing
- No automated tests were run because this change only modifies the workflow file; CI will validate the change on the next workflow run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da3399900832f8a11708af79bebd0)