### PR TITLE
Clarify branch create/delete push events

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -88,10 +88,25 @@ export function parseReleaseEvent(payload: any): ParsedEvent | null {
  * 需求 4.3, 4.6: 提取分支名、提交列表（最多5条）和推送者信息
  */
 export function parsePushEvent(payload: any): ParsedEvent | null {
-  const {ref, commits, repository, sender, compare} = payload
+  const {ref, commits, repository, sender, compare, created, deleted} = payload
 
   // 提取分支名（去掉 refs/heads/ 前缀）
   const branch = ref?.replace('refs/heads/', '') || ''
+
+  if ((!commits || commits.length === 0) && (created || deleted)) {
+    const actionText = created ? '创建分支' : '删除分支'
+    const type = created ? 'create' : 'delete'
+
+    return {
+      type,
+      displayType: getDisplayType(type),
+      repo: repository.full_name,
+      actor: sender.login,
+      action: actionText,
+      ref: branch,
+      url: repository.html_url,
+    }
+  }
 
   // 解析提交列表
   const allCommits: CommitInfo[] = (commits || []).map((commit: any) => ({


### PR DESCRIPTION
### Motivation
- Avoid returning `null` for zero-commit push payloads that represent branch creation or deletion and make the produced event explicit and clearly worded.

### Description
- Update `parsePushEvent` in `src/parser.ts` to destructure `created` and `deleted`, move branch extraction earlier, and when `commits` is empty and `created`/`deleted` is set return a `create` or `delete` `ParsedEvent` with `action` set to `创建分支` or `删除分支` and `ref` containing the branch name.
- Preserve the normal `push` parsing path by returning a `push` `ParsedEvent` for non-zero-commit pushes and keep existing commit mapping and truncation to `MAX_COMMITS`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69893f28cab8832f95ff80e23a04b14e)